### PR TITLE
Equality of Optionals with tests.

### DIFF
--- a/src/main/java/org/assertj/guava/api/OptionalAssert.java
+++ b/src/main/java/org/assertj/guava/api/OptionalAssert.java
@@ -1,4 +1,4 @@
-/**
+  /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
@@ -40,12 +40,12 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
   Failures failures = Failures.instance();
 
   protected OptionalAssert(final Optional<T> actual) {
-    super(actual, OptionalAssert.class);
+   super(actual, OptionalAssert.class);
   }
 
   // visible for test
   protected Optional<T> getActual() {
-    return actual;
+   return actual;
   }
 
   /**
@@ -66,14 +66,14 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * @throws AssertionError if the actual {@link Optional} contains nothing or does not have the given value.
    */
   public OptionalAssert<T> contains(final Object value) {
-    Objects.instance().assertNotNull(info, actual);
-    if (!actual.isPresent()) {
-      throw failures.failure(info, shouldBePresentWithValue(value));
-    }
-    if (!actual.get().equals(value)) {
-      throw failures.failure(info, shouldBePresentWithValue(actual, value));
-    }
-    return this;
+   Objects.instance().assertNotNull(info, actual);
+   if (!actual.isPresent()) {
+     throw failures.failure(info, shouldBePresentWithValue(value));
+   }
+   if (!actual.get().equals(value)) {
+     throw failures.failure(info, shouldBePresentWithValue(actual, value));
+   }
+   return this;
   }
 
   /**
@@ -93,11 +93,11 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * @throws AssertionError if the actual {@link Optional} contains a (non-null) instance.
    */
   public OptionalAssert<T> isAbsent() {
-    Objects.instance().assertNotNull(info, actual);
-    if (actual.isPresent()) {
-      throw failures.failure(info, shouldBeAbsent(actual));
-    }
-    return this;
+   Objects.instance().assertNotNull(info, actual);
+   if (actual.isPresent()) {
+     throw failures.failure(info, shouldBeAbsent(actual));
+   }
+   return this;
   }
 
   /**
@@ -117,11 +117,59 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * @throws AssertionError if the actual {@link Optional} contains a null instance.
    */
   public OptionalAssert<T> isPresent() {
-    Objects.instance().assertNotNull(info, actual);
-    if (!actual.isPresent()) {
-      throw failures.failure(info, shouldBePresent(actual));
-    }
-    return this;
+   Objects.instance().assertNotNull(info, actual);
+   if (!actual.isPresent()) {
+     throw failures.failure(info, shouldBePresent(actual));
+   }
+   return this;
   }
 
+  /**
+   * Verifies that the actual {@link Optional} equals expected {@link Optional} instance.<br>
+   * <p>
+   * Example :
+   *
+   * <pre>
+   * Optional&lt;String&gt; optional = Optional.of(&quot;value&quot;);
+   * Optional&lt;String&gt; equalOptional = Optional.of(&quot;value&quot;);
+   *
+   * assertThat(optional).equals(equalOptional);
+   * </pre><br>
+   *
+   * Or :
+   *
+   * <pre>
+   * Optional&lt;String&gt; optional = Optional.absent();
+   * Optional&lt;String&gt; equalOptional = Optional.absent();
+   *
+   * assertThat(optional).equals(equalOptional);
+   * </pre>
+   *
+   * @return this {@link OptionalAssert} for assertions chaining.
+   *
+   * @throws AssertionError if the actual {@link Optional} is {@code null}.
+   * @throws AssertionError if the expected {@link Optional} is {@code null}.
+   * @throws AssertionError if the actual {@link Optional} is absent while the expected value contains a (non null) instance.
+   * @throws AssertionError if the actual {@link Optional} contains a (non null) instance while the expected value is absent.
+   */
+  public OptionalAssert<T> isEqualTo(Optional<T> expected) {
+   Objects.instance().assertNotNull(info, actual);
+   if(expected == null){
+     failWithMessage("\nExpected Optional was null", expected);
+   }
+   if (!expected.isPresent() && actual.isPresent()){
+     throw failures.failure(info, shouldBeAbsent(actual));
+   }
+   if (expected.isPresent() && !actual.isPresent()){
+     throw failures.failure(info, shouldBePresent(actual));
+   }
+   if (actual.isPresent() && expected.isPresent()){
+     T actualValue = actual.get();
+     T expectedValue = expected.get();
+     if (!actualValue.equals(expectedValue)){
+       throw failures.failure(info, shouldBePresentWithValue(actual, expectedValue));
+     }
+   }
+   return this;
+  }
 }

--- a/src/test/java/org/assertj/guava/api/OptionalAssert_equals_Test.java
+++ b/src/test/java/org/assertj/guava/api/OptionalAssert_equals_Test.java
@@ -1,0 +1,80 @@
+package org.assertj.guava.api;
+
+import com.google.common.base.Optional;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+public class OptionalAssert_equals_Test extends BaseTest {
+
+  @Test
+  public void should_pass_if_actual_equals_option() {
+   // given
+   Optional<String> expected = Optional.fromNullable("some value");
+   Optional<String> actual = Optional.fromNullable("some value");
+   // when
+   assertThat(actual).isEqualTo(expected);
+   // then
+   // pass
+  }
+
+  @Test
+  public void should_fail_if_actual_is_absent_and_expected_is_present() throws Exception {
+   // given
+   Optional<String> expected = Optional.fromNullable("X");
+   Optional<String> actual = Optional.absent();
+   // expect
+   expectException(AssertionError.class,
+     "Expecting Optional to contain a non-null instance but contained nothing (absent Optional)");
+   // when
+   assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_present_and_expected_is_absent() throws Exception {
+   // given
+   Optional<String> expected = Optional.absent();
+   Optional<String> actual = Optional.fromNullable("X");
+   // expect
+   expectException(AssertionError.class,
+     "Expecting Optional to contain nothing (absent Optional) but contained <\"X\">");
+   // when
+   assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_and_expected_values_are_not_equal() throws Exception {
+   // given
+   Optional<String> expected = Optional.fromNullable("X");
+   Optional<String> actual = Optional.fromNullable("Y");
+   // expect
+   expectException(AssertionError.class,
+     "\nExpecting Optional to contain value \n<\"X\">\n but contained \n<\"Y\">");
+   // when
+   assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() throws Exception {
+   // given
+   Optional<String> expected = Optional.fromNullable("X");
+   Optional<String> actual = null;
+   // expect
+   expectException(AssertionError.class, actualIsNull());
+   // when
+   assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_fail_if_expected_is_null() throws Exception {
+   // given
+   Optional<String> actual = Optional.fromNullable("X");
+   // expect
+   expectException(AssertionError.class,
+     "\nExpected Optional was null");
+   // when
+   assertThat(actual).isEqualTo(null);
+  }
+}


### PR DESCRIPTION
Hi, 

I've implemented isEqualTo for optionals, makes it easier to compare lots of optionals (for example optional fields on a larger class) and would be useful to us on a project where we use lots of optionals.

I wasn't sure about the error messages for failed assertions, so I've re-used existing ones where possible.
I also had trouble importing the assertJ eclipse settings, so I've manually formatted to match the other optional assertions and tests.

I've prepared an example, which I'll submit as a seperate pull request to the examples repo.

Feedback much appreciated.

Cheers - Andrew.

If both are absent, they're equal
If both are present, falls through to equality of the values.
If either (or both) are null (not even absent), fails.
