### PR TITLE
Replace `org.assertj.core.internal.Objects` with method reference

### DIFF
--- a/src/main/java/org/assertj/guava/api/RangeSetAssert.java
+++ b/src/main/java/org/assertj/guava/api/RangeSetAssert.java
@@ -31,8 +31,7 @@ import com.google.common.collect.RangeSet;
  */
 public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<RangeSetAssert<T>, RangeSet<T>> {
 
-  @VisibleForTesting
-  RangeSets rangeSets = RangeSets.instance();
+  private final RangeSets rangeSets = new RangeSets(objects::assertNotNull);
 
   protected RangeSetAssert(RangeSet<T> actual) {
     super(actual, RangeSetAssert.class);

--- a/src/main/java/org/assertj/guava/internal/RangeSets.java
+++ b/src/main/java/org/assertj/guava/internal/RangeSets.java
@@ -38,10 +38,10 @@ import static org.assertj.guava.internal.ErrorMessages.rangeSetValuesToLookForIs
 import static org.assertj.guava.util.ExceptionUtils.throwIllegalArgumentExceptionIfTrue;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Failures;
-import org.assertj.core.internal.Objects;
 import org.assertj.core.util.VisibleForTesting;
 
 import com.google.common.collect.Range;
@@ -54,18 +54,13 @@ import com.google.common.collect.RangeSet;
  */
 public class RangeSets {
 
-  private final static RangeSets INSTANCE = new RangeSets();
+  private final BiConsumer<AssertionInfo, RangeSet<?>> assertNotNull;
 
   @VisibleForTesting
   Failures failures = Failures.instance();
 
-  /**
-   * Returns singleton instance of this class.
-   *
-   * @return singleton instance of this class.
-   */
-  public static RangeSets instance() {
-    return INSTANCE;
+  public RangeSets(BiConsumer<AssertionInfo, RangeSet<?>> assertNotNull) {
+    this.assertNotNull = java.util.Objects.requireNonNull(assertNotNull);
   }
 
   /**
@@ -668,7 +663,7 @@ public class RangeSets {
   }
 
   private void assertNotNull(AssertionInfo info, RangeSet<?> actual) {
-    Objects.instance().assertNotNull(info, actual);
+    assertNotNull.accept(info, actual);
   }
 
   private void failIfNull(Object[] array) {

--- a/src/test/java/org/assertj/guava/internal/RangeSetsBaseTest.java
+++ b/src/test/java/org/assertj/guava/internal/RangeSetsBaseTest.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.TreeRangeSet.create;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.WritableAssertionInfo;
+import org.assertj.core.internal.Objects;
 import org.junit.jupiter.api.BeforeEach;
 
 import com.google.common.collect.ImmutableRangeSet;
@@ -44,7 +45,7 @@ public abstract class RangeSetsBaseTest {
     this.actual.add(closed(15, 20));
     this.actual.add(open(30, 35));
 
-    this.rangeSets = new RangeSets();
+    this.rangeSets = new RangeSets(Objects.instance()::assertNotNull);
   }
 
   protected AssertionInfo someInfo() {

--- a/src/test/java/org/assertj/guava/internal/rangesets/RangeSets_constructor_Test.java
+++ b/src/test/java/org/assertj/guava/internal/rangesets/RangeSets_constructor_Test.java
@@ -1,0 +1,19 @@
+package org.assertj.guava.internal.rangesets;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.assertj.guava.internal.RangeSets;
+import org.junit.jupiter.api.Test;
+
+class RangeSets_constructor_Test {
+
+  @Test
+  void should_fail_if_assertNotNull_is_null() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> new RangeSets(null));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+}


### PR DESCRIPTION
This change removes the dependency to `org.assertj.core.internal.Objects` in the main code.

See #70.